### PR TITLE
Add payload to include request data for Ticker and implement AddOrder

### DIFF
--- a/nodes/private/user-trading/add-standard-order.html
+++ b/nodes/private/user-trading/add-standard-order.html
@@ -3,10 +3,12 @@ RED.nodes.registerType('add-standard-order',{
   category: 'krakenAPI',
   color: '#85bf77',
   defaults: {
+    kraken: {type: "kraken-credentials", validate: validateKrakenNode},
     name: {value:""}
   },
   inputs:1,
-  outputs:1,
+  outputs:2,
+  outputLabels: ["result","error"],
   icon: "node_kraken.png",
   label: function() {
     return this.name||"add-standard-order";
@@ -15,12 +17,18 @@ RED.nodes.registerType('add-standard-order',{
 </script>
 
 <script type="text/x-red" data-template-name="add-standard-order">
-<div class="form-row">
-<label for="node-input-name"><i class="icon-tag"></i> Name</label>
-<input type="text" id="node-input-name" placeholder="Name">
-</div>
+	<div class="form-row">
+		<label for="node-input-kraken"><i class="icon-lock"></i>Credential</label>
+		<input type="text" id="node-input-kraken">
+	</div>
+	<div class="form-row">
+		<label for="node-input-name"><i class="icon-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
 </script>
 
 <script type="text/x-red" data-help-name="add-standard-order">
 <p>Node-RED package to support the Kraken API.</p>
+<p>Pass the order parameters into the payload.</p>
+<p>See the <a href='https://www.kraken.com/features/api#add-standard-order'>API documentation</a> for details</p>
 </script>

--- a/nodes/private/user-trading/add-standard-order.js
+++ b/nodes/private/user-trading/add-standard-order.js
@@ -1,12 +1,35 @@
 module.exports = function(RED) {
   function AddStandardOrder(config) {
-    RED.nodes.createNode(this,config);
+	RED.nodes.createNode(this,config);
     var node = this;
+	node.status({});
+	node.kraken = RED.nodes.getNode(config.kraken);
     node.on('input', function(msg) {
-      // on.input run your actual functionality here
-      // return 'send' the output for the next node
-      node.send(msg);
-    });
+		console.error(node)
+		if (!node.kraken) {
+			node.error(RED._("kraken.errors.missing-conf"), msg);
+			return;
+		}
+	
+		var krakencli = node.kraken ? node.kraken.client: null;
+		console.error(krakencli)
+		
+		this.status({ fill: 'blue', shape: 'dot', text: 'requesting' })
+	  
+		krakencli.api('AddOrder',msg.payload)
+		.then(result => {
+		//	console.log(result);
+			  msg.payload = result.result
+			  node.send([msg, null])
+			  this.status({})
+		})
+		.catch(error => {
+		  this.status({ fill: 'red', shape: 'dot', text: 'error' })
+		  msg.payload = error
+		  node.send([null, msg])
+		})	
+
+    });  
   }
   RED.nodes.registerType("add-standard-order", AddStandardOrder);
 }

--- a/nodes/public/market-data/get-ticker-information.html
+++ b/nodes/public/market-data/get-ticker-information.html
@@ -24,4 +24,6 @@ RED.nodes.registerType('get-ticker-information',{
 
 <script type="text/x-red" data-help-name="get-ticker-information">
 <p>Node-RED package to support the Kraken API.</p>
+<p>Pass in the pair key in the payload containing a coma delimited list of asset pairs to get info on</p>
+<p>See the <a href='https://www.kraken.com/features/api#get-ticker-info'>API documentation</a> for details</p>
 </script>

--- a/nodes/public/market-data/get-ticker-information.js
+++ b/nodes/public/market-data/get-ticker-information.js
@@ -12,7 +12,7 @@ module.exports = function(RED) {
 		node.on('input', function(msg) {
 			this.status({ fill: 'blue', shape: 'dot', text: 'requesting' })
 		  
-			kraken.api('Ticker')
+			kraken.api('Ticker', msg.payload)
 			.then(result => {
 				console.log(result);
 				  msg.payload = result.result


### PR DESCRIPTION
- Add payload to include request data for Ticker, without this, the calls weren't usable to me.
- Implemented AddOrder code so that orders can be sent. 